### PR TITLE
fix 3.11 ValueErrorr

### DIFF
--- a/ae64.py
+++ b/ae64.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 from copy import deepcopy
 
@@ -21,7 +21,7 @@ class MulCacheStruct:
 
 @dataclass
 class MulGadgetStruct:
-    mul: MulCacheStruct = MulCacheStruct()
+    mul: MulCacheStruct = field(default_factory=MulCacheStruct)
     offset: int = 0
 
 
@@ -34,8 +34,8 @@ class EncodeInfoStruct:
 
 @dataclass
 class EncodeInfoPlusStruct:
-    info: EncodeInfoStruct = EncodeInfoStruct()
-    gadget: MulGadgetStruct = MulGadgetStruct()
+    info: EncodeInfoStruct = field(default_factory=EncodeInfoStruct)
+    gadget: MulGadgetStruct =  field(default_factory=MulGadgetStruct)
     needPushByte: bool = False
     needChangeRdi: bool = False
     needChangeRdx: bool = False


### PR DESCRIPTION
    Python 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from ae64 import AE64 
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/mnt/hgfs/0/mypython/ae64.py", line 22, in <module>
        @dataclass
         ^^^^^^^^^
      File "/usr/lib/python3.11/dataclasses.py", line 1220, in dataclass
        return wrap(cls)
               ^^^^^^^^^
      File "/usr/lib/python3.11/dataclasses.py", line 1210, in wrap
        return _process_class(cls, init, repr, eq, order, unsafe_hash,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/dataclasses.py", line 958, in _process_class
        cls_fields.append(_get_field(cls, name, type, kw_only))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/dataclasses.py", line 815, in _get_field
        raise ValueError(f'mutable default {type(f.default)} for field '
    ValueError: mutable default <class 'ae64.MulCacheStruct'> for field mul is not allowed: use default_factory
    >>> 

In python3.11 , use default_factory

such as

`mul: MulCacheStruct = field(default_factory=MulCacheStruct)`

In python 3.10 ,it is ok to use

    Python 3.10.4 (main, Mar 24 2022, 13:07:27) [GCC 11.2.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from ae64 import AE64
    >>>